### PR TITLE
リポジトリの構造の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 .Trash-*
 .nfs*
 
+# MySQL data
+db/data
+
+node_modules

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -7,7 +7,9 @@ services:
     ports:
       - "3307:3306"
     volumes:
-      - "./db_data:/var/lib/mysql"
+      - type: bind
+        source: "./data"
+        target: "/var/lib/mysql"
     environment:
       MARIADB_ROOT_PASSWORD: "password" # `root`ユーザのパスワード
       MARIADB_DATABASE: "testdb" # 初期化時に作成するデータベース


### PR DESCRIPTION
* `node_modules` と MySQL データベースのデータは Git リポジトリに含めるべきではありませんので、`.gitignore` に追加しました。
* MySQL データベース周りのディレクトリ構造を簡略化しました。